### PR TITLE
Adds info about single-click deployment for Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 This is a wrapper of etherpad-lite for Heroku, incorporating the official release from upstream as a submodule. (This will hopefully make it easier to keep current.)
 
-## quickstart
+## Automatic one-click deployment for Heroku
+Click the "Deploy to Heroku" button at https://elements.heroku.com/buttons/waterloo/etherpad-lite-heroku and you're ready to go.
+
+## Quickstart (manual approach)
 
 1. Set up a Heroku account and configure an app with DB of your choice (default MySQL)
 2. Clone this repo into a directory of your choice


### PR DESCRIPTION
I discovered the according Heroku button https://elements.heroku.com/buttons/waterloo/etherpad-lite-heroku.

After deploying the app it currently crashes with:
```
2017-01-31T14:14:24.902097+00:00 app[web.1]: 	from ./preparse.rb:7:in `<main>'
2017-01-31T14:14:26.383871+00:00 heroku[web.1]: Starting process with command `./preparse.rb`
2017-01-31T14:14:28.503672+00:00 heroku[web.1]: State changed from starting to crashed
2017-01-31T14:14:28.480091+00:00 heroku[web.1]: Process exited with status 1
2017-01-31T14:14:28.402700+00:00 app[web.1]: /usr/lib/ruby/1.9.1/uri/common.rb:176:in `split': bad URI(is not URI?):  (URI::InvalidURIError)
2017-01-31T14:14:28.402717+00:00 app[web.1]: 	from /usr/lib/ruby/1.9.1/uri/common.rb:211:in `parse'
2017-01-31T14:14:28.402720+00:00 app[web.1]: 	from /usr/lib/ruby/1.9.1/uri/common.rb:747:in `parse'
2017-01-31T14:14:28.402721+00:00 app[web.1]: 	from ./preparse.rb:7:in `<main>'
```

Have you been able to fix this?